### PR TITLE
Add responsive navigation and about section

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,53 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
+    <!-- Navigation -->
+    <nav class="bg-white shadow navbar-shadow">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between h-16">
+                <div class="flex items-center">
+                    <a href="#" class="font-bold text-xl">MyLogo</a>
+                </div>
+                <div class="hidden md:flex items-center space-x-4">
+                    <a href="#" class="nav-link">Home</a>
+                    <a href="#about" class="nav-link">About</a>
+                    <div class="relative group">
+                        <button class="nav-link focus:outline-none">Courses</button>
+                        <div class="dropdown-menu">
+                            <a href="#course1" class="nav-link">Course 1</a>
+                            <a href="#course2" class="nav-link">Course 2</a>
+                            <a href="#course3" class="nav-link">Course 3</a>
+                        </div>
+                    </div>
+                    <a href="#contact" class="px-3 py-2 rounded-md text-white bg-indigo-600 hover:bg-indigo-700">Contact Me</a>
+                </div>
+                <div class="flex items-center md:hidden">
+                    <button id="mobile-menu-button" class="nav-link focus:outline-none">
+                        <svg class="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div id="mobile-menu" class="md:hidden hidden px-2 pt-2 pb-3 space-y-1">
+            <a href="#" class="nav-link">Home</a>
+            <a href="#about" class="nav-link">About</a>
+            <button id="mobile-courses-button" class="nav-link flex justify-between items-center w-full">
+                <span>Courses</span>
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+                </svg>
+            </button>
+            <div id="mobile-courses-dropdown" class="hidden pl-4 space-y-1">
+                <a href="#course1" class="nav-link">Course 1</a>
+                <a href="#course2" class="nav-link">Course 2</a>
+                <a href="#course3" class="nav-link">Course 3</a>
+            </div>
+            <a href="#contact" class="nav-link bg-indigo-600 text-white rounded-md">Contact Me</a>
+        </div>
+    </nav>
+
     <!-- Hero Section -->
     <section class="bg-white">
         <div class="max-w-7xl mx-auto py-24 px-4 sm:px-6 lg:px-8 text-center">
@@ -25,5 +72,26 @@
             </div>
         </div>
     </section>
+
+    <!-- About Section -->
+    <section id="about" class="bg-gray-50">
+        <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
+            <div class="grid md:grid-cols-2 gap-8 items-center">
+                <div>
+                    <h2 class="text-3xl font-extrabold text-gray-900">About Me</h2>
+                    <p class="mt-4 text-lg text-gray-600">
+                        I am a passionate developer who loves building responsive and
+                        interactive web experiences using modern tools like Tailwind
+                        CSS.
+                    </p>
+                </div>
+                <div class="flex justify-center">
+                    <img src="https://placekitten.com/400/300" alt="About me" class="rounded-lg shadow-lg" />
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -6,5 +6,23 @@
 
 'use strict';
 
-// TODO: implement functionality
+// Mobile menu toggle
+document.addEventListener('DOMContentLoaded', function () {
+    const mobileMenuButton = document.getElementById('mobile-menu-button');
+    const mobileMenu = document.getElementById('mobile-menu');
+    const mobileCoursesButton = document.getElementById('mobile-courses-button');
+    const mobileCoursesDropdown = document.getElementById('mobile-courses-dropdown');
+
+    if (mobileMenuButton) {
+        mobileMenuButton.addEventListener('click', () => {
+            mobileMenu.classList.toggle('hidden');
+        });
+    }
+
+    if (mobileCoursesButton) {
+        mobileCoursesButton.addEventListener('click', () => {
+            mobileCoursesDropdown.classList.toggle('hidden');
+        });
+    }
+});
 

--- a/style.css
+++ b/style.css
@@ -5,3 +5,30 @@ h1 {
 body {
     background-color: #f9fafb;
 }
+
+/* Navigation styles */
+.nav-link {
+    color: #4b5563; /* text-gray-700 */
+    padding: 0.5rem 0.75rem;
+    display: block;
+}
+
+.nav-link:hover {
+    color: #111827; /* text-gray-900 */
+}
+
+.dropdown-menu {
+    display: none;
+    position: absolute;
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.25rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    margin-top: 0.5rem;
+    min-width: 10rem;
+    z-index: 50;
+}
+
+.group:hover > .dropdown-menu {
+    display: block;
+}


### PR DESCRIPTION
## Summary
- add responsive navigation with dropdown and mobile menu
- create new About Me section with two-column layout
- implement toggling behavior in `script.js`
- style navigation elements in `style.css`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684110f95f2483269bd781e852307fe4