### PR TITLE
Add sticky mini menu section

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,8 @@
         <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
             <h2 class="text-3xl font-extrabold text-gray-900">Plans</h2>
             <p class="mt-4 text-lg text-gray-600">Choose the plan that fits your needs.</p>
+            <p class="mt-2 text-gray-600">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas pretium ipsum nec leo imperdiet, in faucibus dui blandit. Donec in semper velit. Sed vitae purus aliquet, elementum neque eu, tempor metus.</p>
+            <p class="mt-2 text-gray-600">Curabitur non ante vel diam blandit vehicula. Praesent dignissim justo ut suscipit euismod. Donec eget massa sed turpis faucibus efficitur. In hac habitasse platea dictumst.</p>
         </div>
     </section>
 
@@ -98,6 +100,8 @@
         <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
             <h2 class="text-3xl font-extrabold text-gray-900">Benefits</h2>
             <p class="mt-4 text-lg text-gray-600">Discover what you gain by working with us.</p>
+            <p class="mt-2 text-gray-600">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed efficitur, lorem sed laoreet sagittis, mi felis posuere justo, ut vulputate tellus nisl quis risus.</p>
+            <p class="mt-2 text-gray-600">Aliquam erat volutpat. Nulla facilisi. Donec accumsan libero at lectus consequat, et dapibus enim sollicitudin. Pellentesque habitant morbi tristique senectus et netus.</p>
         </div>
     </section>
 
@@ -106,6 +110,8 @@
         <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
             <h2 class="text-3xl font-extrabold text-gray-900">How It Works</h2>
             <p class="mt-4 text-lg text-gray-600">A simple explanation of our process.</p>
+            <p class="mt-2 text-gray-600">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin in elit sed quam ullamcorper feugiat. Etiam sed bibendum metus, ac blandit leo.</p>
+            <p class="mt-2 text-gray-600">Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed at magna quis nulla feugiat cursus.</p>
         </div>
     </section>
 
@@ -114,6 +120,8 @@
         <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
             <h2 class="text-3xl font-extrabold text-gray-900">What's Included</h2>
             <p class="mt-4 text-lg text-gray-600">See everything that comes in the package.</p>
+            <p class="mt-2 text-gray-600">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque id dui vitae velit venenatis sagittis. Mauris lacinia varius mauris, non facilisis nulla malesuada vitae.</p>
+            <p class="mt-2 text-gray-600">Nunc et turpis eu dolor sollicitudin cursus. Nam gravida, mauris nec efficitur faucibus, sem sapien sagittis elit, a luctus nisi risus at ipsum.</p>
         </div>
     </section>
 
@@ -122,6 +130,8 @@
         <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
             <h2 class="text-3xl font-extrabold text-gray-900">FAQ</h2>
             <p class="mt-4 text-lg text-gray-600">Frequently asked questions.</p>
+            <p class="mt-2 text-gray-600">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras porta, massa at consectetur finibus, elit sapien fringilla sem, et condimentum nisl velit a justo.</p>
+            <p class="mt-2 text-gray-600">Suspendisse potenti. Sed non lacus non ipsum sollicitudin pharetra. Nunc bibendum, arcu id rhoncus efficitur, metus libero bibendum sapien, sed scelerisque elit nisi ut ligula.</p>
         </div>
     </section>
 
@@ -136,6 +146,8 @@
                         interactive web experiences using modern tools like Tailwind
                         CSS.
                     </p>
+                    <p class="mt-2 text-gray-600">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce eget interdum justo. Integer convallis sollicitudin metus, vel tempor elit viverra in.</p>
+                    <p class="mt-2 text-gray-600">Phasellus non massa in sapien consequat egestas. Vivamus at urna quis ipsum ullamcorper viverra quis id urna.</p>
                 </div>
                 <div class="flex justify-center">
                     <img src="https://placekitten.com/400/300" alt="About me" class="rounded-lg shadow-lg" />

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body>
+    <div id="top"></div>
     <!-- Navigation -->
     <nav class="bg-white shadow navbar-shadow">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -70,6 +71,57 @@
                     Get Started
                 </a>
             </div>
+        </div>
+    </section>
+
+    <!-- In-page Mini Menu -->
+    <nav id="mini-menu" class="mini-menu">
+        <ul class="flex justify-center space-x-4">
+            <li><a href="#plans">Plans</a></li>
+            <li><a href="#benefits">Benefits</a></li>
+            <li><a href="#how-it-works">How It Works</a></li>
+            <li><a href="#whats-included">What's Included</a></li>
+            <li><a href="#faq">FAQ</a></li>
+        </ul>
+    </nav>
+
+    <!-- Plans Section -->
+    <section id="plans" data-section class="bg-white">
+        <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-extrabold text-gray-900">Plans</h2>
+            <p class="mt-4 text-lg text-gray-600">Choose the plan that fits your needs.</p>
+        </div>
+    </section>
+
+    <!-- Benefits Section -->
+    <section id="benefits" data-section class="bg-gray-50">
+        <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-extrabold text-gray-900">Benefits</h2>
+            <p class="mt-4 text-lg text-gray-600">Discover what you gain by working with us.</p>
+        </div>
+    </section>
+
+    <!-- How It Works Section -->
+    <section id="how-it-works" data-section class="bg-white">
+        <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-extrabold text-gray-900">How It Works</h2>
+            <p class="mt-4 text-lg text-gray-600">A simple explanation of our process.</p>
+        </div>
+    </section>
+
+    <!-- What's Included Section -->
+    <section id="whats-included" data-section class="bg-gray-50">
+        <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-extrabold text-gray-900">What's Included</h2>
+            <p class="mt-4 text-lg text-gray-600">See everything that comes in the package.</p>
+        </div>
+    </section>
+
+    <!-- FAQ Section -->
+    <section id="faq" data-section class="bg-white">
+        <div class="max-w-7xl mx-auto py-16 px-4 sm:px-6 lg:px-8">
+            <h2 class="text-3xl font-extrabold text-gray-900">FAQ</h2>
+            <p class="mt-4 text-lg text-gray-600">Frequently asked questions.</p>
         </div>
     </section>
 

--- a/script.js
+++ b/script.js
@@ -24,5 +24,27 @@ document.addEventListener('DOMContentLoaded', () => {
             mobileCoursesDropdown.classList.toggle('hidden');
         });
     }
+
+    const miniMenuLinks = document.querySelectorAll('#mini-menu a');
+    const sections = document.querySelectorAll('[data-section]');
+
+    if (miniMenuLinks.length && sections.length) {
+        const observer = new IntersectionObserver((entries) => {
+            entries.forEach(entry => {
+                if (entry.isIntersecting) {
+                    miniMenuLinks.forEach(link => {
+                        const targetId = link.getAttribute('href').substring(1);
+                        if (targetId === entry.target.id) {
+                            link.classList.add('active');
+                        } else {
+                            link.classList.remove('active');
+                        }
+                    });
+                }
+            });
+        }, { threshold: 0.5 });
+
+        sections.forEach(section => observer.observe(section));
+    }
 });
 

--- a/style.css
+++ b/style.css
@@ -33,3 +33,28 @@ body {
 .group:hover > .dropdown-menu {
     display: block;
 }
+
+html {
+    scroll-behavior: smooth;
+}
+
+/* Mini menu styles */
+.mini-menu {
+    position: sticky;
+    top: 0;
+    z-index: 40;
+    background-color: #ffffff;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+.mini-menu a {
+    color: #4b5563;
+    padding: 0.5rem 1rem;
+    display: block;
+}
+
+.mini-menu a.active {
+    color: #111827;
+    font-weight: 600;
+    border-bottom: 2px solid #6366f1;
+}


### PR DESCRIPTION
## Summary
- add a new sticky mini menu that links to five new sections
- highlight mini menu items using IntersectionObserver
- add CSS styles for the new menu and smooth scrolling
- insert placeholder sections for Plans, Benefits, How It Works, What's Included, and FAQ

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841f286a3ec83268935f6253997281d